### PR TITLE
capebus: Geiger Cape config bugfixs

### DIFF
--- a/drivers/capebus/capes/bone-geiger-cape.c
+++ b/drivers/capebus/capes/bone-geiger-cape.c
@@ -417,8 +417,8 @@ static int bonegeiger_probe(struct cape_dev *dev, const struct cape_device_id *i
 				"vsense-name", &info->vsense_name) != 0) {
 		info->vsense_name = "AIN5";
 		dev_warn(&dev->dev, "Could not read vsense-name property; "
-				"using default %u\n",
-					val);
+				"using default '%s'\n",
+					info->vsense_name);
 	}
 
 	if (capebus_of_property_read_u32(dev,


### PR DESCRIPTION
The display of 'vsense-name' default is incorrect.

Signed-off-by: Matt Ranostay mranostay@gmail.com
