### PR TITLE
am335x-bone: Add spi0 pins defines

### DIFF
--- a/arch/arm/boot/dts/am335x-bone-common.dtsi
+++ b/arch/arm/boot/dts/am335x-bone-common.dtsi
@@ -24,6 +24,14 @@
 	};
 
 	am3358_pinmux: pinmux@44e10800 {
+		spi0_pins: pinmux_spi0_pins {
+			pinctrl-single,pins = <
+				0x150 0x10      /* spi0_sclk.gpio0_2, OUTPUT_PULLUP | MODE0 */
+				0x154 0x30      /* spi0_d0.gpio0_3, INPUT_PULLUP | MODE0 */
+				0x158 0x10      /* spi0_d1.i2c1_sda, OUTPUT_PULLUP | MODE0 */
+				0x15c 0x10      /* spi0_cs0.i2c1_scl, OUTPUT_PULLUP | MODE0 */
+			>;
+		};
 		spi1_pins: pinmux_spi1_pins {
 			pinctrl-single,pins = <
 				0x190 0x13	/* mcasp0_aclkx.spi1_sclk, OUTPUT_PULLUP | MODE3 */
@@ -399,6 +407,11 @@
 
 &mmc1 {
 	vmmc-supply = <&ldo3_reg>;
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_pins>;
 };
 
 &spi1 {


### PR DESCRIPTION
Sometimes you need use the other SPI bus in the device tree due to
pin muxing this allows easy references for switching.

Signed-off-by: Matt Ranostay mranostay@gmail.com
