### PR TITLE
Make single .dtb targets also with DTC_FLAGS

### DIFF
--- a/arch/arm/Makefile
+++ b/arch/arm/Makefile
@@ -299,7 +299,7 @@ uImage-dtb.%: scripts
 	$(Q)$(MAKE) $(build)=$(boot) MACHINE=$(MACHINE) $(boot)/$@
 
 %.dtb: scripts
-	$(Q)$(MAKE) $(build)=$(boot)/dts MACHINE=$(MACHINE) $(boot)/dts/$@
+	$(Q)$(MAKE) $(build)=$(boot)/dts MACHINE=$(MACHINE) DTC_FLAGS=$(DTC_FLAGS) $(boot)/dts/$@
 
 dtbs: scripts
 	$(Q)$(MAKE) $(build)=$(boot)/dts MACHINE=$(MACHINE) DTC_FLAGS=$(DTC_FLAGS) dtbs


### PR DESCRIPTION
I came across this problem while trying to build your kernel within buildroot.
ie. "make am335x-bone.dtb" also need the -@ switch to insert **symbols** in the resulting dtb just like "make dtbs" does
